### PR TITLE
replaceAll(): change the type of string index to size_t

### DIFF
--- a/Utils.cpp
+++ b/Utils.cpp
@@ -477,7 +477,7 @@ ostream& operator<<(std::ostream& os, const Statistic<double> &stat) { stat.text
 string replaceAll(const std::string input, const std::string search, const std::string replace)
 {
 	string output = input;
- 	unsigned index1 = 0;
+ 	size_t index1 = 0;
 
 	while (index1 < output.size()) {
 	  try {


### PR DESCRIPTION
Integer type `unsigned` can not hold result from string::find(), may lead to error like below:

```
Utils.cpp:493:replaceAll: string replaceAll error index1=4294967295 input=IMSI TMSI IMEI AUTH CREATED ACCESSED TMSI_ASSIGNED search=  replace=, output=IMSI,TMSI,IMEI,AUTH,CREATED,ACCESSED,TMSI_ASSIGNED
```